### PR TITLE
smartcrop handler: added check if eyedistance env var is an empty string

### DIFF
--- a/src/smartcrop/handler.py
+++ b/src/smartcrop/handler.py
@@ -23,8 +23,12 @@ def upload_image(image, object_key):
 def process_image(image, landmarks):
     canvas_width, canvas_height = 3200, 2450
     target_eye_level = 988
-    min_eye_distance = float(os.getenv('EYEDISTANCE', 220))
-
+    
+    if os.getenv('EYEDISTANCE') == '':
+        min_eye_distance = float(220)
+    else:
+        min_eye_distance = float(os.getenv('EYEDISTANCE', 220))
+    
     # Extract the eye positions from the landmarks data
     left_eye = next((item for item in landmarks if item['Type'] == 'leftEyeRight'), None)
     right_eye = next((item for item in landmarks if item['Type'] == 'rightEyeLeft'), None)


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Added a condition in the smart crop lambda handler to check whether the env var EYEDISTANCE is set to an empty string. I noticed sam deploy prompts the user for EYEDISTANCE and sets it to an empty string if not provided. This leads to a type conversion error when the smart crop lambda tries to run; specifically when it looks for the env var EYEDISTANCE, finds an empty string, and tries to convert to float. The addition of the condition should handle the case where env var EYEDISTANCE is set to an empty or valid string, or applies the default value of 220 if it's not set at all.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
